### PR TITLE
query-rewrite: Re-add support for the pkg keyword

### DIFF
--- a/cmd/dcs-web/search/query-rewrite.go
+++ b/cmd/dcs-web/search/query-rewrite.go
@@ -24,6 +24,7 @@ func rewriteFilters(query url.Values, filtersRe *regexp.Regexp) url.Values {
 		filter := strings.ToLower(matches[1])
 		value := matches[2]
 
+		filter = strings.Replace(filter, "pkg", "package", 1)
 		if filter == "-file" {
 			filter = "npath"
 		} else if strings.HasPrefix(filter, "-") {

--- a/cmd/dcs-web/search/query-rewrite_test.go
+++ b/cmd/dcs-web/search/query-rewrite_test.go
@@ -92,6 +92,28 @@ func TestRewriteQuery(t *testing.T) {
 		t.Fatalf("Expected npackage %q, got %q", "i3-WM", pkg)
 	}
 
+	// Verify that the pkg: alias is recognized (case-sensitively)
+	rewritten = rewrite(t, "/search?q=searchterm+pkg%3Ai3-WM")
+	querystr = rewritten.Query().Get("q")
+	if querystr != "searchterm" {
+		t.Fatalf("Expected search query %q, got %q", "searchterm", querystr)
+	}
+	pkg = rewritten.Query().Get("package")
+	if pkg != "i3-WM" {
+		t.Fatalf("Expected package %q, got %q", "i3-WM", pkg)
+	}
+
+	// Verify that the -pkg: (negative) alias is recognized (case-sensitively)
+	rewritten = rewrite(t, "/search?q=searchterm+-pkg%3Ai3-WM")
+	querystr = rewritten.Query().Get("q")
+	if querystr != "searchterm" {
+		t.Fatalf("Expected search query %q, got %q", "searchterm", querystr)
+	}
+	pkg = rewritten.Query().Get("npackage")
+	if pkg != "i3-WM" {
+		t.Fatalf("Expected package %q, got %q", "i3-WM", pkg)
+	}
+
 	// Verify that -file is translated to npath
 	rewritten = rewrite(t, "/search?q=searchterm+-file:foo")
 	querystr = rewritten.Query().Get("q")


### PR DESCRIPTION
Regression introduced in e0c55fd66c79cc622c0efe710e808474c21da1eb.

Closes #65
Signed-off-by: James McCoy <jamessan@debian.org>