### PR TITLE
Phrase the error message when there's no result in a nicer manner.

### DIFF
--- a/static/instant.js
+++ b/static/instant.js
@@ -318,7 +318,7 @@ function getDefault(searchparams, name, def) {
 function onQueryDone(msg) {
     if (msg.Results === 0) {
         progress(100, false, msg.FilesTotal + ' files grepped (' + msg.Results + ' results)');
-        error(false, true, 'noresults', 'Your query “' + searchterm + '” had no results. Did you read the FAQ to make sure your syntax is correct?');
+        error(false, true, 'noresults', 'Your query “' + searchterm + '” had no results. Please read the FAQ to make sure your syntax is correct.');
         return;
     }
 


### PR DESCRIPTION
"Did you read the FAQ" may be interpreted by some users of the service as
a reproach about not having read it already. This conflicts with the usage path
that's encouraged: the homepage does mention the FAQ but not as a compulsory
first step before using the service; for example, the focus is set by default in
the search box.

So when there's no result, let's instead guide the user towards one of the
possible paths to solving their problem, that is the FAQ. Ideally the word "FAQ"
in this error message would be a link to the FAQ but I lack time to learn how to
test such changes myself right now.