### PR TITLE
Pass a bool to the results page form for the "literal" variable

### DIFF
--- a/cmd/dcs-web/serverrendered.go
+++ b/cmd/dcs-web/serverrendered.go
@@ -343,7 +343,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 		"packages":    packages,
 		"pagination":  template.HTML(pagination),
 		"q":           r.Form.Get("q"),
-		"literal":     literal,
+		"literal":     literal == "1",
 		"page":        page,
 		"host":        r.Host,
 		"version":     common.Version,


### PR DESCRIPTION
This fixes the selection of the right option in the form.