### PR TITLE
Add <link> for OpenSearch autodiscovery

### DIFF
--- a/cmd/dcs-web/templates/index.html
+++ b/cmd/dcs-web/templates/index.html
@@ -9,6 +9,10 @@ vim:ts=4:sw=4:expandtab
 </style>
 <link rel="preload" href="/non-critical.min.css" as="style" onload="this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="/non-critical.min.css"></noscript>
+<link rel="search"
+  type="application/opensearchdescription+xml"
+  href="/opensearch.xml"
+  title="Debian Code Search">
 </head>
 <body>
 

--- a/cmd/dcs-web/templates/index.html
+++ b/cmd/dcs-web/templates/index.html
@@ -44,7 +44,7 @@ vim:ts=4:sw=4:expandtab
 <input type="text" name="q" autofocus="autofocus">
 <select name="literal">
 <option value="1" selected>literal</option>
-<option value="0">regex</opiton>
+<option value="0">regex</option>
 </select>
 <input type="submit" value="Search">
 </form>

--- a/cmd/dcs-web/templates/results.html
+++ b/cmd/dcs-web/templates/results.html
@@ -60,6 +60,10 @@ pre {
 </style>
 <link rel="preload" href="/non-critical.min.css" as="style" onload="this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="/non-critical.min.css"></noscript>
+<link rel="search"
+  type="application/opensearchdescription+xml"
+  href="/opensearch.xml"
+  title="Debian Code Search">
 </head>
 <body>
 


### PR DESCRIPTION
Great project!  I was hoping to add it to my Firefox search engines, but, although `opensearch.xml` is available, my browser couldn't find it because it isn't linked from the HTML pages as described in [OpenSearch Autodiscovery in HTML/XHTML].  This PR adds the necessary `<link>` element to the search and results pages.

Thanks for considering,
Kevin

P.S. It also fixes a small typo I noticed.  If you'd prefer that commit be submitted separately, let me know.

[OpenSearch Autodiscovery in HTML/XHTML]: https://github.com/dewitt/opensearch/blob/c9ed38a/opensearch-1-1-draft-6.md#autodiscovery-in-htmlxhtm